### PR TITLE
Explicitely put name of Digital Asset on sponsors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,12 @@ This work is licensed under the Mozilla Public License 2.0. See
 
 ## Sponsors
 
-[![Digital Asset](https://avatars1.githubusercontent.com/u/9829909?s=200&v=4)](http://digitalasset.com)
+This work has been sponsored by [Digital Asset](https://digitalasset.com) and [Tweag I/O](https://tweag.io).
 
-This work is maintained by [<img src="https://www.tweag.io/img/tweag-med.png" height="30">](http://tweag.io)
+[![Digital Asset](https://avatars1.githubusercontent.com/u/9829909?s=200&v=4)](http://digitalasset.com)
+[![Tweag I/O](https://avatars1.githubusercontent.com/u/6057932?s=200&v=4)](https://tweag.io)
+
+This repository is maintained by [Tweag I/O](http://tweag.io)
 
 Have questions? Need help? Tweet at
 [@tweagio](http://twitter.com/tweagio).


### PR DESCRIPTION
This puts the name of DA explicitly on the list of sponsors, as asked by Mathieu.

It also puts DA and Tweag's logo in the same style. I was unable to find a PNG logo of DA including the "Digital Asset" written in their webpage, that's why I use the simple logo for both.

The DA PNG logo can be downloaded from a ZIP on https://brand.digitalasset.com/, but it would have to be included in the repo, which seems overkill.